### PR TITLE
fix OmniSharp/omnisharp-atom/276 bail early when project path is null

### DIFF
--- a/lib/drivers/stdio.ts
+++ b/lib/drivers/stdio.ts
@@ -56,6 +56,14 @@ class StdioDriver implements IDriver {
             projectPath = projectFinder(projectPath, this._logger);
         }
 
+        if (!projectPath) {
+          var error = "Failed to determine project path for omnisharp, aborting connect()";
+          this._logger.error(error);
+          this.serverErr(error);
+          this.disconnect();
+          return;
+        }
+
         this._connectionStream.onNext(DriverState.Connecting);
 
         var serverArguments: any[] = ["--stdio", "-s", projectPath, "--hostPID", process.pid];

--- a/lib/drivers/stdio.ts
+++ b/lib/drivers/stdio.ts
@@ -86,7 +86,7 @@ class StdioDriver implements IDriver {
 
     private serverErr(data) {
         var friendlyMessage = this.parseError(data);
-        this.currentState = DriverState.Error;
+        this._connectionStream.onNext(DriverState.Error);
         this._process = null;
 
         this._eventStream.onNext({

--- a/spec/stdio-spec.ts
+++ b/spec/stdio-spec.ts
@@ -63,18 +63,32 @@ describe("Omnisharp Local - Stdio", function() {
                 projectPath: process.cwd()
             });
 
-            server.connect({});
-            server.state.subscribe(state => {
+            var sub = server.state.subscribe(state => {
                 expect(server.currentState).to.be.not.null;
                 expect(server.commands).to.be.not.null;
                 expect(server.events).to.be.not.null;
                 expect(server.state).to.be.not.null;
                 expect(server.outstandingRequests).to.be.not.null;
+                done();
+                sub.dispose();
+            });
+            server.connect({});
+        })
+    })
+
+    describe("properties", function() {
+        this.timeout(20000);
+        it('should disconnect if no project path is given', function(done) {
+            var server = new Stdio({
+                driver: Driver.Stdio
             });
 
-            done();
+            var sub  = server.state.subscribe(state => {
+                expect(state).to.be.eql(DriverState.Error);
+                done();
+                sub.dispose();
+            });
+            server.connect({});
         })
-
-
     })
 });


### PR DESCRIPTION
I was getting bit by this too: 

https://github.com/OmniSharp/omnisharp-atom/issues/276

When starting the omnisharp server on our omnisharp-atom project.