### PR TITLE
Priority ordering

### DIFF
--- a/lib/drivers.ts
+++ b/lib/drivers.ts
@@ -15,6 +15,7 @@ export interface IDriverOptions {
     serverPath?: string; // Start a given server, perhaps in a different directory.
     findProject?: boolean; // Should try and find the project using the project finder
     logger?: ILogger;
+    timeout?: number; // timeout in seconds
 }
 
 export interface IDriver {

--- a/lib/omnisharp-client.ts
+++ b/lib/omnisharp-client.ts
@@ -4,8 +4,14 @@ import {assert} from "chai";
 import {extend, uniqueId, some} from "lodash";
 import { findCandidates as candidateFinder} from "./candidate-finder";
 
-var normalCommands = [];
-var priorityCommands = ['updatebuffer', 'changebuffer'];
+var normalCommands = [
+    'findimplementations', 'findsymbols', 'findusages',
+    'gotodefinition', 'gotofile', 'gotoregion', 'typelookup',
+    'navigateup', 'navigatedown', 'projects', 'project'
+];
+var priorityCommands = [
+    'updatebuffer', 'changebuffer', 'filesChanged'
+];
 var undeferredCommands = normalCommands.concat(priorityCommands);
 
 export enum Driver {

--- a/omnisharp-client.d.ts
+++ b/omnisharp-client.d.ts
@@ -17,10 +17,11 @@ declare module OmnisharpClient {
     export interface IDriverOptions {
         projectPath?: string;
         remote?: boolean;
-        debug?: boolean;
-        serverPath?: string;
+        debug?: boolean; // Start the debug server? (Run from source, to attach with a debug host like VS)
+        serverPath?: string; // Start a given server, perhaps in a different directory.
         findProject?: boolean; // Should try and find the project using the project finder
         logger?: ILogger;
+        timeout?: number; // timeout in seconds
     }
     export interface OmnisharpClientOptions extends IDriverOptions {
         driver?: Driver;

--- a/spec/stdio-spec.ts
+++ b/spec/stdio-spec.ts
@@ -69,8 +69,8 @@ describe("Omnisharp Local - Stdio", function() {
                 expect(server.events).to.be.not.null;
                 expect(server.state).to.be.not.null;
                 expect(server.outstandingRequests).to.be.not.null;
-                done();
                 sub.dispose();
+                done();
             });
             server.connect({});
         })


### PR DESCRIPTION
This forces all commands except for `updatebuffer` or `changebuffer` to be queued until the final `updatebuffer` or `changebuffer` has completed.

We have the ability to pass other commands through, by adding them to the `undeferredCommands` array. Things like `autocomplete` could potentially use this.