### PR TITLE
change order of homebrew mono and official mono

### DIFF
--- a/vendor/omnisharp.patch
+++ b/vendor/omnisharp.patch
@@ -10,6 +10,6 @@ DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
 export SET DNX_APPBASE="$DIR/packages/OmniSharp/1.0.0/root"
 
-export PATH=$PATH:/usr/local/bin # this is required for the users of the Homebrew Mono package
+export PATH=/usr/local/bin:$PATH # this is required for the users of the Homebrew Mono package
 
 exec "$DIR/packages/dnx-mono.1.0.0-beta4/bin/dnx" "$DNX_APPBASE" run "$@"


### PR DESCRIPTION
Change the priority order of homebrew mono and official Xamarin mono.

Homebrew mono typically has a higher priority on the PATH than xamarin mono... so I think this should be the expected order to use.

Might lead to less issues as people have latest homebrew installed but an old version of the official package.