### PR TITLE
Removed call to Observable.cache

### DIFF
--- a/lib/helpers/runtime.ts
+++ b/lib/helpers/runtime.ts
@@ -257,9 +257,8 @@ export const isSupportedRuntime = memoize(function (ctx: RuntimeContext) {
             .map(x => ({ runtime: Runtime.ClrOrMono, path: [x.path].concat(PATH).join(delimiter) }))
             .take(1)
             .defaultIfEmpty({ runtime: Runtime.CoreClr, path: process.env.PATH });
-    })
+    });
         //.do(ct => console.log(`Supported runtime for "${Runtime[ct.runtime]}" was: ${Runtime[ct.runtime]}`))
-        .cache(1);
 }, function ({platform, arch, runtime, version}: RuntimeContext) { return `${arch}-${platform}:${Runtime[runtime]}:${version}`; });
 
 function findOmnisharpExecuable(runtimeId: string, location: string): Observable<boolean> {


### PR DESCRIPTION
This method was removed from RxJS-5.0.0 release (ReactiveX/rxjs#2012).

Maybe some caching alternative could be implemented later. I believe that, for now, it needs to be removed to make the library usable again (OmniSharp/omnisharp-atom#880).
