### PR TITLE
Update version from netcoreapp1.0 -> netcoreapp1.1

### DIFF
--- a/lib/helpers/runtime.ts
+++ b/lib/helpers/runtime.ts
@@ -144,7 +144,7 @@ export class RuntimeContext {
             return `mono`;
         }
 
-        let runtimeName = 'netcoreapp1.0';
+        let runtimeName = 'netcoreapp1.1';
         if (this._runtime === Runtime.ClrOrMono) {
             if (this._platform === SupportedPlatform.Windows) {
                 runtimeName = 'net46';


### PR DESCRIPTION
This constant is used to determine which binaries to download from the Roslyn releases page.

Currently, the latest Roslyn release is used, which is determined by the Roslyn version described in the package JSON. However, for the latest version, there are no `netcoreapp1.0` binaries and only `netcoreapp1.1` binaries.

This fixes the download for non-Windows platforms.